### PR TITLE
Update to current stable platform

### DIFF
--- a/io.github.seadve.Kooha.json
+++ b/io.github.seadve.Kooha.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.seadve.Kooha",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
bump runtime to gnome platform 48. Currently selected platform 46 is EoL