### PR TITLE
Update runtime to GNOME 50

### DIFF
--- a/io.github.seadve.Kooha.json
+++ b/io.github.seadve.Kooha.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.seadve.Kooha",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
GNOME 48 went EOL on March 24, 2026. Bumping to the current stable runtime, GNOME 50, to keep Kooha on a supported platform.

Reference:
<img width="1668" height="1217" alt="Screenshot From 2026-05-28 14-26-00" src="https://github.com/user-attachments/assets/0d89bb84-2ca6-40ee-8151-2bbf92a2b93e" />
