### PR TITLE
bump runtime to 50 and version to 2.3.2

### DIFF
--- a/io.github.seadve.Kooha.json
+++ b/io.github.seadve.Kooha.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.seadve.Kooha",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -18,62 +18,15 @@
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin"
     },
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
-        {
-            "name": "x264",
-            "config-opts": [
-                "--enable-shared",
-                "--enable-pic",
-                "--disable-cli"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://code.videolan.org/videolan/x264.git",
-                    "commit": "31e19f92f00c7003fa115047ce50978bc98c3a0d"
-                }
-            ]
-        },
-        {
-            "name": "gst-plugins-ugly",
-            "buildsystem": "meson",
-            "builddir": true,
-            "config-opts": [
-                "-Ddoc=disabled",
-                "-Dnls=disabled",
-                "-Dtests=disabled",
-                "-Dgpl=enabled",
-                "-Dgobject-cast-checks=disabled",
-                "-Dglib-asserts=disabled",
-                "-Dglib-checks=disabled"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.24.13.tar.xz",
-                    "sha256": "dc08bb11dce0a43453466fb9034e4fe06709fb5af68475bcf6d288693b661a5d"
-                }
-            ]
-        },
         {
             "name": "kooha",
             "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/SeaDve/Kooha/releases/download/v2.3.1/kooha-2.3.1.tar.xz",
-                    "sha256": "b9f76ec6a6fac0b4eae63b50246e4d45a83d6e565e3d741fe21ac93572d25e4f"
+                    "url": "https://github.com/SeaDve/Kooha/releases/download/v2.3.2/kooha-2.3.2.tar.xz",
+                    "sha256": "a8f7d0d6fc1418264639a42833d66866475ed0d30b6f1f50b0b430c7d35b3969"
                 }
             ]
         }


### PR DESCRIPTION
Also
- Use the GStreamer module from the runtime
- Drop ineffective cleanup commands

Supercedes #24 and #25